### PR TITLE
feat: Add log level mapping for ducopy and reduce integration log noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ mypy custom_components/duco_ventilation_sun_control
 3. Ensure the DUCO device is powered on and accessible
 4. Check Home Assistant logs for error messages
 
+### Reduce Integration Log Noise
+
+Use Home Assistant's standard logger configuration in `configuration.yaml`:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.duco_ventilation_sun_control: warning
+    ducopy: warning
+```
+
+Set `ducopy` to `warning` or `error` to reduce library log spam while keeping important errors visible.
+
 ### Enable Debug Logging
 
 Add to your `configuration.yaml`:

--- a/custom_components/duco_ventilation_sun_control/__init__.py
+++ b/custom_components/duco_ventilation_sun_control/__init__.py
@@ -17,6 +17,18 @@ DucoboxConfigEntry: TypeAlias = ConfigEntry[DucoPy]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+def _get_ducopy_log_level() -> str:
+    """Map the effective Python log level for ducopy to a DucoPy level string."""
+    level = logging.getLogger("ducopy").getEffectiveLevel()
+    if level <= logging.DEBUG:
+        return "DEBUG"
+    if level <= logging.INFO:
+        return "INFO"
+    if level <= logging.WARNING:
+        return "WARNING"
+    return "ERROR"
+
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Ducobox Connectivity Board integration."""
     _LOGGER.debug("Setting up Ducobox Connectivity Board integration")
@@ -26,13 +38,15 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: DucoboxConfigEntry) -> bool:
     """Set up Ducobox from a config entry."""
     base_url = entry.data["base_url"]
+    log_level = _get_ducopy_log_level()
     _LOGGER.debug(f"Base URL from config entry: {base_url}")
+    _LOGGER.debug("Using DucoPy log level from Python logging: %s", log_level)
 
     try:
         # Initialize DucoPy in executor to avoid blocking the event loop
         # The library auto-detects board generation (Connectivity vs Communication/Print)
         def _init_client():
-            return DucoPy(base_url=base_url, verify=False)
+            return DucoPy(base_url=base_url, verify=False, log_level=log_level)
 
         duco_client = await asyncio.get_running_loop().run_in_executor(None, _init_client)
         _LOGGER.info(f"DucoPy initialized with base URL: {base_url}")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -82,9 +82,7 @@ async def test_log_level_mapping(hass: HomeAssistant, mock_ducopy):
 
         with (
             patch("custom_components.duco_ventilation_sun_control.DucoPy") as mock_ducopy_class,
-            patch(
-                "custom_components.duco_ventilation_sun_control.logging.getLogger"
-            ) as mock_get_logger,
+            patch("custom_components.duco_ventilation_sun_control.logging.getLogger") as mock_get_logger,
         ):
             mock_ducopy_class.return_value = mock_ducopy
             mock_get_logger.return_value.getEffectiveLevel.return_value = logger_level

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Test the DUCO Ventilation & Sun Control integration setup."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -63,25 +64,30 @@ async def test_unload_entry(hass: HomeAssistant, mock_config_entry: MockConfigEn
 
 @pytest.mark.asyncio
 async def test_log_level_mapping(hass: HomeAssistant, mock_ducopy):
-    """Test that debug verbosity is correctly mapped to log levels."""
+    """Test that Python logger levels are mapped to DucoPy log levels."""
     test_cases = [
-        (0, "ERROR"),
-        (1, "WARNING"),
-        (2, "INFO"),
-        (3, "DEBUG"),
+        (logging.ERROR, "ERROR"),
+        (logging.WARNING, "WARNING"),
+        (logging.INFO, "INFO"),
+        (logging.DEBUG, "DEBUG"),
     ]
 
-    for verbosity, expected_log_level in test_cases:
+    for logger_level, expected_log_level in test_cases:
         entry = MockConfigEntry(
             domain=DOMAIN,
             data={"base_url": "https://192.168.1.100"},
-            options={"debug_verbosity": verbosity},
-            unique_id=f"test_{verbosity}",
+            unique_id=f"test_{logger_level}",
         )
         entry.add_to_hass(hass)
 
-        with patch("custom_components.duco_ventilation_sun_control.DucoPy") as mock_ducopy_class:
+        with (
+            patch("custom_components.duco_ventilation_sun_control.DucoPy") as mock_ducopy_class,
+            patch(
+                "custom_components.duco_ventilation_sun_control.logging.getLogger"
+            ) as mock_get_logger,
+        ):
             mock_ducopy_class.return_value = mock_ducopy
+            mock_get_logger.return_value.getEffectiveLevel.return_value = logger_level
             await hass.config_entries.async_setup(entry.entry_id)
             await hass.async_block_till_done()
 


### PR DESCRIPTION
This pull request improves how logging is handled for the DUCO Ventilation & Sun Control integration and its underlying DucoPy library. The changes ensure that DucoPy's log level is automatically mapped from the Python logger configuration, making it easier for users to control log verbosity via Home Assistant's standard logging settings. The documentation and tests have also been updated to reflect and verify this new behavior.

**Logging improvements:**

* Added a `_get_ducopy_log_level` function in `__init__.py` to map the effective Python log level for the `ducopy` logger to the corresponding DucoPy log level string. This ensures that DucoPy respects the log level set in Home Assistant's logger configuration.
* Modified the `async_setup_entry` function to pass the mapped log level to the DucoPy client during initialization, so log output is consistent with the configured logger level.

**Documentation updates:**

* Updated `README.md` with instructions on how to reduce integration log noise by configuring the logger in `configuration.yaml`, including an example for setting `ducopy` and the integration to `warning` or `error`.

**Testing enhancements:**

* Updated tests in `test_init.py` to verify that the Python logger levels are correctly mapped to DucoPy log levels, including patching the logger and checking the integration's behavior for each level.
* Added the necessary import for the `logging` module in the test file.