### PR TITLE
feat: Add VLVCO2 sensor entity descriptions for ventilation control

### DIFF
--- a/custom_components/duco_ventilation_sun_control/nodes.py
+++ b/custom_components/duco_ventilation_sun_control/nodes.py
@@ -153,6 +153,51 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             node_type="VLV",
         ),
     ],
+    "VLVCO2": [
+        DucoboxNodeSensorEntityDescription(
+            key="Mode",
+            value_fn=lambda node: node.get("node_data", {}).get("Ventilation", {}).get("Mode"),
+            icon="mdi:fan-auto",
+            sensor_key="Mode",
+            node_type="VLVCO2",
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key="FlowLvlTgt",
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get("node_data", {}).get("Ventilation", {}).get("FlowLvlTgt"),
+            icon="mdi:fan-chevron-up",
+            sensor_key="FlowLvlTgt",
+            node_type="VLVCO2",
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key="FlowLvl",
+            native_unit_of_measurement=PERCENTAGE,
+            value_fn=lambda node: node.get("node_data", {}).get("Ventilation", {}).get("FlowLvl"),
+            icon="mdi:fan",
+            sensor_key="FlowLvl",
+            node_type="VLVCO2",
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key="Co2",
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.CO2,
+            value_fn=lambda node: _process_node_co2(
+                node.get("node_data", {}).get("Sensor", {}).get("data", {}).get("Co2")
+            ),
+            sensor_key="Co2",
+            node_type="VLVCO2",
+        ),
+        DucoboxNodeSensorEntityDescription(
+            key="IaqCo2",
+            native_unit_of_measurement=PERCENTAGE,
+            icon="mdi:crosshairs",
+            value_fn=lambda node: _process_node_iaq(
+                node.get("node_data", {}).get("Sensor", {}).get("data", {}).get("IaqCo2")
+            ),
+            sensor_key="IaqCo2",
+            node_type="VLVCO2",
+        ),
+    ],
     "VLVCO2RH": [
         DucoboxNodeSensorEntityDescription(
             key="Mode",


### PR DESCRIPTION
This pull request adds support for a new node type, `VLVCO2`, to the `nodes.py` file in the `duco_ventilation_sun_control` custom component. The main change is the introduction of several sensor entity descriptions for this node type, enabling monitoring of ventilation and CO2-related metrics.

New node type and sensors:

* Added a new node type, `VLVCO2`, with sensor entity descriptions for:
  - Ventilation mode (`Mode`)
  - Target flow level (`FlowLvlTgt`)
  - Actual flow level (`FlowLvl`)
  - CO2 concentration (`Co2`)
  - IAQ CO2 percentage (`IaqCo2`)
 