### PR TITLE
Add temperature sensor description for VLVCO2

### DIFF
--- a/custom_components/duco_ventilation_sun_control/nodes.py
+++ b/custom_components/duco_ventilation_sun_control/nodes.py
@@ -197,6 +197,16 @@ NODE_SENSORS: dict[str, list[DucoboxNodeSensorEntityDescription]] = {
             sensor_key="IaqCo2",
             node_type="VLVCO2",
         ),
+        DucoboxNodeSensorEntityDescription(
+            key="Temp",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            value_fn=lambda node: _process_node_temperature(
+                node.get("node_data", {}).get("Sensor", {}).get("data", {}).get("Temp")
+            ),
+            sensor_key="Temp",
+            node_type="VLVCO2",
+        ),
     ],
     "VLVCO2RH": [
         DucoboxNodeSensorEntityDescription(


### PR DESCRIPTION
## Description
Add a `Temp` (temperature) sensor for `VLVCO2` nodes. This node type already exposes a temperature reading (`Sensor.data.Temp`) via the DUCO API, but it was previously not defined in `NODE_SENSORS["VLVCO2"]`, so no temperature entity was ever created for these valves. This mirrors the existing `Temp` sensor already defined for `VLVCO2RH` and `VLVRH` node types.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Related Issue
N/A

## How Has This Been Tested?
- [x] Confirmed on a live DucoBox Focus setup: after adding the `Temp` sensor description to `VLVCO2`, the new `sensor.<location>_vlvco2_temperature` entities appeared correctly and report valid values for both a salon and a toilette VLVCO2 valve.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Commit Message Format
feat: add temperature sensor for VLVCO2 nodes